### PR TITLE
Passing arguments as hashref with named parameters

### DIFF
--- a/t/02_clean.t
+++ b/t/02_clean.t
@@ -45,7 +45,7 @@ readme_from 'README.pm' => 'clean', 'text', 'Foobar.txt', \@options;
 \@options = ( '--backlink="Back to Top"', '--flush' );
 readme_from 'README.pm' => 'clean', 'html', 'Foobar.htm', \@options;
 \@options = ( 'release' => 1.03, 'section' => 8 );
-readme_from 'README.pm' => 'clean', 'man', 'Foobar.man', \@options;
+readme_from 'README.pm', { clean => 1, format => 'man', output_file => 'Foobar.man', options => \\\@options };
 WriteAll;
 EOF
 close MFPL;


### PR DESCRIPTION
Hi Chris,

Thanks for pulling yesterday's changes. As mentionned, instead of a long list of arguments, whose meaning is unclear, I implemented passing arguments to readme_from as a hashred with named parameters:
`readme_from 'lib/Some/Module.pm', { clean => 1, format => 'htm', output_file => 'SomeModule.html' };`

This changeset is compatible with earlier versions of Module::Install::ReadmeFromPod and I think it makes using the module user-friendlier.
Best,

Florent
