### PR TITLE
only load IO::All and Capture::Tiny in admin mode

### DIFF
--- a/lib/Module/Install/ReadmeFromPod.pm
+++ b/lib/Module/Install/ReadmeFromPod.pm
@@ -5,14 +5,51 @@ use strict;
 use warnings;
 use base qw(Module::Install::Base);
 use vars qw($VERSION);
-use IO::All -binary;
-use Capture::Tiny 'capture';
 
 $VERSION = '0.22';
+
+{
+
+    # these aren't defined until after _require_admin is run, so
+    # define them so prototypes are available during compilation.
+    sub io;
+    sub capture(&;@);
+
+=pod
+
+=begin quiet_pod_coverage
+
+=head2 io
+
+=head2 capture
+
+=end quiet_pod_coverage
+
+=cut
+
+    my $done = 0;
+
+    sub _require_admin {
+
+	# do this once to avoid redefinition warnings from IO::All
+	return if $done;
+
+	require IO::All;
+	IO::All->import( '-binary' );
+
+	require Capture::Tiny;
+	Capture::Tiny->import ( 'capture' );
+
+	return;
+    }
+
+}
 
 sub readme_from {
   my $self = shift;
   return unless $self->is_admin;
+
+  _require_admin;
 
   # Input file
   my $in_file  = shift || $self->_all_from


### PR DESCRIPTION
IO::All and Capture::Tiny are only used in admin mode, but they are always being loaded, causing build errors for distributions build in environments which don't have them installed.  This ensures they are only loaded in admin mode.